### PR TITLE
Иван Шаныгин Б09 ДЗ №3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ OBJS = \
   $K/sysfile.o \
   $K/kernelvec.o \
   $K/plic.o \
-  $K/virtio_disk.o
+  $K/virtio_disk.o \
+  $K/mutex.o \
+  $K/sysmutex.o \
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
@@ -133,6 +135,7 @@ UPROGS=\
 	$U/_wc\
 	$U/_zombie\
 	$U/_test_no_mutex\
+	$U/_test_mutex\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
+	$U/_test_no_mutex\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -8,6 +8,7 @@ struct spinlock;
 struct sleeplock;
 struct stat;
 struct superblock;
+struct mutex;
 
 // bio.c
 void            binit(void);
@@ -184,6 +185,13 @@ void            plic_complete(int);
 void            virtio_disk_init(void);
 void            virtio_disk_rw(struct buf *, int);
 void            virtio_disk_intr(void);
+
+// mutex.c
+void            mutex_init(void);
+int             mutex_create(void);
+int             mutex_destroy(int);
+int             mutex_lock(int);
+int             mutex_unlock(int);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x)/sizeof((x)[0]))

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -27,6 +27,7 @@ main()
     binit();         // buffer cache
     iinit();         // inode table
     fileinit();      // file table
+    mutex_init();    // mutex table 
     virtio_disk_init(); // emulated hard disk
     userinit();      // first user process
     __sync_synchronize();

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -96,16 +96,18 @@ mutex_destroy(int mutex_desc) {
         release(&mtable_lock);
         return -1; // nothing to destroy
     }
-
+    
     struct proc *p = myproc();
     for (int i = 0; i < NOMUTEX; i++) {
         if (p->omutex[i] == &mtable[mutex_desc]) {
             mtable[mutex_desc].descriptors_num -= 1;
-            
+
             release(&mtable_lock);
             p->omutex[i] = 0;
+
+            mutex_unlock(mutex_desc);
             return 0;     // successfully destroy mutex for proc p           
-        }    
+        }   
     } 
     release(&mtable_lock);
     return -2;    // no mutex in mutexes of proc p

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -1,0 +1,114 @@
+#include "types.h"
+#include "riscv.h"
+#include "defs.h"
+#include "param.h"
+#include "stat.h"
+#include "spinlock.h"
+#include "proc.h"
+#include "sleeplock.h"
+#include "fs.h"
+#include "buf.h"
+#include "file.h"
+#include "mutex.h"
+
+struct mutex mtable[NMUTEX];
+struct spinlock mtable_lock;
+
+void
+mutex_init(void) {
+    initlock(&mtable_lock, "mutex table spinlock");  // init mutex table global spinlock 
+    
+    acquire(&mtable_lock);                           // lock all table
+    for (int i = 0 ; i < NMUTEX; i++) {
+        mtable[i].descriptors_num = 0;
+        initsleeplock(&mtable[i].lock, "mutex sleeplock"); // init mutex sleeplock
+    }
+    release(&mtable_lock);
+}
+
+int
+mutex_lock(int mutex_desc) {
+    if (holdingsleep(&mtable[mutex_desc].lock)) {
+        return -1;      // mutex already locked
+    }
+    
+    acquire(&mtable_lock);
+    if (mtable[mutex_desc].descriptors_num == 0) {
+        release(&mtable_lock);
+        return -2;      // mutex isn't used by any process
+    }
+    release(&mtable_lock);
+    acquiresleep(&mtable[mutex_desc].lock);
+    
+    return 0;           // successfully locked mutex
+}
+
+int
+mutex_unlock(int mutex_desc) {
+    if (holdingsleep(&mtable[mutex_desc].lock) == 0) {
+        return -1;      // mutex already unlocked
+    }
+    
+    acquire(&mtable_lock);
+    if (mtable[mutex_desc].descriptors_num == 0) {
+        release(&mtable_lock);
+        return -2;      // mutex isn't used by any process
+    }
+    release(&mtable_lock);
+    releasesleep(&mtable[mutex_desc].lock);
+
+    return 0;           // successfully unlocked mutex
+}
+
+int 
+mutex_create(void) {
+    struct proc *p = myproc();
+    int created_mutex_desc = -1;
+
+    acquire(&mtable_lock); // lock mutex table
+    for (int i = 0; i < NMUTEX; i++) {
+        if (mtable[i].descriptors_num == 0) {
+            mtable[i].descriptors_num += 1;
+            created_mutex_desc = i;
+            break;
+        }
+    }
+    release(&mtable_lock);
+
+    if (created_mutex_desc != -1) {
+        for (int i = 0; i < NOMUTEX; i++) {
+            if (p->omutex[i] == 0) {
+                p->omutex[i] = &mtable[created_mutex_desc];
+                return created_mutex_desc;  
+            } 
+        }
+        return -1;     // too many mutexes per one proc
+    }
+    else {
+        return -2;     // all mutexes are busy
+    }
+}
+
+int
+mutex_destroy(int mutex_desc) {
+    acquire(&mtable_lock);
+    if (mtable[mutex_desc].descriptors_num == 0) {
+        release(&mtable_lock);
+        return -1; // nothing to destroy
+    }
+
+    struct proc *p = myproc();
+    for (int i = 0; i < NOMUTEX; i++) {
+        if (p->omutex[i] == &mtable[mutex_desc]) {
+            mtable[mutex_desc].descriptors_num -= 1;
+            
+            release(&mtable_lock);
+            p->omutex[i] = 0;
+            return 0;     // successfully destroy mutex for proc p           
+        }    
+    } 
+    release(&mtable_lock);
+    return -2;    // no mutex in mutexes of proc p
+}
+
+

--- a/kernel/mutex.h
+++ b/kernel/mutex.h
@@ -1,0 +1,9 @@
+#ifndef MUTEX_H
+#define MUTEX_H
+
+struct mutex {
+    int descriptors_num;
+    struct sleeplock lock;
+};
+
+#endif

--- a/kernel/mutex.h
+++ b/kernel/mutex.h
@@ -3,6 +3,7 @@
 
 struct mutex {
     int descriptors_num;
+    int pid;
     struct sleeplock lock;
 };
 

--- a/kernel/param.h
+++ b/kernel/param.h
@@ -2,6 +2,8 @@
 #define NCPU          8  // maximum number of CPUs
 #define NOFILE       16  // open files per process
 #define NFILE       100  // open files per system
+#define NOMUTEX      16  // open mutexes per process
+#define NMUTEX       128 // maximum number of mutexes
 #define NINODE       50  // maximum number of active i-nodes
 #define NDEV         10  // maximum major device number
 #define ROOTDEV       1  // device number of file system root disk

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -381,6 +381,7 @@ exit(int status)
   for (int i = 0; i < NOMUTEX; i++) {
     if (p->omutex[i] != 0) {
       p->omutex[i]->descriptors_num -= 1;
+      p->omutex[i] = 0;
     }
   }
   release(&mutex_table_lock);

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -102,6 +102,7 @@ struct proc {
   struct trapframe *trapframe; // data page for trampoline.S
   struct context context;      // swtch() here to run process
   struct file *ofile[NOFILE];  // Open files
+  struct mutex *omutex[NOMUTEX]; // Open mutexes
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)
 };

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,10 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_mutex_create(void);
+extern uint64 sys_mutex_destroy(void);
+extern uint64 sys_mutex_lock(void);
+extern uint64 sys_mutex_unlock(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +130,10 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_mutex_create]  sys_mutex_create,
+[SYS_mutex_destroy] sys_mutex_destroy,
+[SYS_mutex_lock]    sys_mutex_lock,
+[SYS_mutex_unlock]  sys_mutex_unlock,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,7 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_mutex_create  22
+#define SYS_mutex_destroy 23
+#define SYS_mutex_lock    24
+#define SYS_mutex_unlock  25

--- a/kernel/sysmutex.c
+++ b/kernel/sysmutex.c
@@ -1,0 +1,33 @@
+#include "types.h"
+#include "riscv.h"
+#include "defs.h"
+#include "param.h"
+#include "memlayout.h"
+#include "spinlock.h"
+#include "proc.h"
+
+uint64
+sys_mutex_create(void) {
+    return mutex_create();
+}
+
+uint64
+sys_mutex_destroy(void) {
+    int mutex_desc;
+    argint(0, &mutex_desc);
+    return mutex_destroy(mutex_desc);
+}
+
+uint64
+sys_mutex_lock(void) {
+    int mutex_desc;
+    argint(0, &mutex_desc);
+    return mutex_lock(mutex_desc);
+}
+
+uint64
+sys_mutex_unlock(void) {
+    int mutex_desc;
+    argint(0, &mutex_desc);
+    return mutex_unlock(mutex_desc);
+}

--- a/user/test_mutex.c
+++ b/user/test_mutex.c
@@ -2,61 +2,90 @@
 #include "kernel/stat.h"
 #include "user/user.h"
 
-#define FORK_ERR_LEN       22
-#define PIPE_ERR_LEN       31
-#define CMD_ARGS_ERR_LEN   34
-#define WRITE_PIPE_ERR_LEN 34
-#define READ_PIPE_ERR_LEN  38
-
+#define FORK_ERR_LEN        22
+#define PIPE_ERR_LEN        31
+#define CMD_ARGS_ERR_LEN    34
+#define WRITE_PIPE_ERR_LEN  34
+#define READ_PIPE_ERR_LEN   38
+#define MTX_CREATE_ERR_LEN  31
+#define MTX_LOCK_ERR_LEN    33
+#define MTX_UNLOCK_ERR_LEN  35
+#define MTX_DESTROY_ERR_LEN 32
 
 int
 main(int argc, char *argv[]) {
     if (argc != 2) {
         write(2, "Error: wrong number of arguments!\n", CMD_ARGS_ERR_LEN);
-        exit(1);
+        exit(3);
     }
     
+    // create mutex
+    int mutex = mutex_create();
+    if (mutex < 0) {
+        write(2, "Error: failed to create mutex!\n", MTX_CREATE_ERR_LEN);
+        exit(6);
+    }
+
     int pd_fst[2]; 
     int pd_snd[2];  
     if (pipe(pd_fst) < 0 || pipe(pd_snd)) {
         write(2, "Error: failed to create pipes!\n", PIPE_ERR_LEN);
-        exit(1);
+        exit(2);
     }
     
     int pid = fork();
     if (pid < 0) {
         write(2, "Error: failed to fork!\n", FORK_ERR_LEN);
-        exit(2);
+        exit(1);
     }
     else if (pid == 0) {           // child proc
         close(pd_fst[1]);
         close(pd_snd[0]);
 
-        int read_result;
+        int read_result, mtx_code;
         char buf;
 
         // read symbols from parent proc
         while ((read_result = read(pd_fst[0], &buf, 1)) > 0) {
+            
+            mtx_code = mutex_lock(mutex);
+            if (mtx_code < 0) {
+                write(2, "Error: failed to lock the mutex!\n", MTX_LOCK_ERR_LEN);
+                exit(7);
+            }
+
+            // mutex provides locking of console output        
             printf("%d: received '%c'\n", getpid(), buf); 
+            
+            mtx_code = mutex_unlock(mutex);
+            if (mtx_code < 0) {
+                write(2, "Error: failed to unlock the mutex!\n", MTX_UNLOCK_ERR_LEN);
+                exit(8);
+            }
             
             // send symbol to parent proc
             if (write(pd_snd[1], &buf, 1) < 0) {
                 write(2, "Error: failed to write into pipe!\n", WRITE_PIPE_ERR_LEN);
                 close(pd_snd[1]);
                 close(pd_fst[0]);
-                exit(3);
+                exit(4);
             }            
-
         }
         if (read_result < 0) {
             write(2, "Error: failed to read data from pipe!\n", READ_PIPE_ERR_LEN);
             close(pd_fst[0]);
             close(pd_snd[1]);
-            exit(4);
+            exit(5);
         }
 
-        close(pd_fst[0]);
         close(pd_snd[1]);
+        close(pd_fst[0]);
+        
+        if (mutex_destroy(mutex) < 0) {
+            write(2, "Error: failed to destroy mutex!\n", MTX_DESTROY_ERR_LEN);
+            exit(9);
+        }
+        
         exit(0);
     }
     else {                         // parent proc  
@@ -68,24 +97,41 @@ main(int argc, char *argv[]) {
             write(2, "Error: failed to write into pipe!\n", WRITE_PIPE_ERR_LEN);
             close(pd_fst[1]);
             close(pd_snd[0]);
-            exit(5);
+            exit(4);
         }
         close(pd_fst[1]);
 
-        int read_result;
+        int read_result, mtx_code;
         char buf;
 
         // read symbols from child proc
         while ((read_result = read(pd_snd[0], &buf, 1)) > 0) {
+            mtx_code = mutex_lock(mutex);
+            if (mtx_code < 0) {
+                write(2, "Error: failed to lock the mutex!\n", MTX_LOCK_ERR_LEN);
+                exit(7);
+            }
+            // mutex provides locking of console output 
             printf("%d: received '%c'\n", getpid(), buf);
+
+            mtx_code = mutex_unlock(mutex);
+            if (mtx_code < 0) {
+                write(2, "Error: failed to unlock the mutex!\n", MTX_UNLOCK_ERR_LEN);
+                exit(8);
+            }
         }
         if (read_result < 0) {
             write(2, "Error: failed to read data from pipe!\n", READ_PIPE_ERR_LEN);
             close(pd_fst[1]);
             close(pd_snd[0]);
-            exit(6);
+            exit(5);
         }
         close(pd_snd[0]);
+
+        if (mutex_destroy(mutex) < 0) {
+            write(2, "Error: failed to destroy mutex!\n", MTX_DESTROY_ERR_LEN);
+            exit(9);
+        }
 
         wait((int *)0);
     }

--- a/user/test_no_mutex.c
+++ b/user/test_no_mutex.c
@@ -1,0 +1,94 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+#define FORK_ERR_LEN       22
+#define PIPE_ERR_LEN       31
+#define CMD_ARGS_ERR_LEN   34
+#define WRITE_PIPE_ERR_LEN 34
+#define READ_PIPE_ERR_LEN  38
+
+
+int
+main(int argc, char *argv[]) {
+    if (argc != 2) {
+        write(2, "Error: wrong number of arguments!\n", CMD_ARGS_ERR_LEN);
+        exit(1);
+    }
+    
+    int pd_fst[2]; 
+    int pd_snd[2];  
+    if (pipe(pd_fst) < 0 || pipe(pd_snd)) {
+        write(2, "Error: failed to create pipes!\n", PIPE_ERR_LEN);
+        exit(1);
+    }
+    
+    int pid = fork();
+    if (pid < 0) {
+        write(2, "Error: failed to fork!\n", FORK_ERR_LEN);
+        exit(2);
+    }
+    else if (pid == 0) {           // child proc
+        close(pd_fst[1]);
+        close(pd_snd[0]);
+
+        int read_result;
+        char buf;
+
+        // read symbols from parent proc
+        while ((read_result = read(pd_fst[0], &buf, 1)) > 0) {
+            printf("%d: received '%c'\n", getpid(), buf); 
+            
+            // send symbol to parent proc
+            if (write(pd_snd[1], &buf, 1) < 0) {
+                write(2, "Error: failed to write into pipe!\n", WRITE_PIPE_ERR_LEN);
+                close(pd_snd[1]);
+                close(pd_fst[0]);
+                exit(3);
+            }            
+
+        }
+        if (read_result < 0) {
+            write(2, "Error: failed to read data from pipe!\n", READ_PIPE_ERR_LEN);
+            close(pd_fst[0]);
+            close(pd_snd[1]);
+            exit(4);
+        }
+
+        close(pd_fst[0]);
+        close(pd_snd[1]);
+        exit(0);
+    }
+    else {                         // parent proc  
+        close(pd_fst[0]);
+        close(pd_snd[1]);
+
+        // send argument to child proc
+        if (write(pd_fst[1], argv[1], strlen(argv[1])) < 0) {
+            write(2, "Error: failed to write into pipe!\n", WRITE_PIPE_ERR_LEN);
+            close(pd_fst[1]);
+            close(pd_snd[0]);
+            exit(5);
+        }
+
+        int read_result;
+        char buf;
+
+        // read symbols from child proc
+        while ((read_result = read(pd_snd[0], &buf, 1)) > 0) {
+            printf("%d: received '%c'\n", getpid(), buf);
+        }
+        if (read_result < 0) {
+            write(2, "Error: failed to read data from pipe!\n", READ_PIPE_ERR_LEN);
+            close(pd_fst[1]);
+            close(pd_snd[0]);
+            exit(6);
+        }
+        close(pd_snd[0]);
+        close(pd_fst[1]);
+
+        wait((int *)0);
+    }
+
+    exit(0);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -22,6 +22,10 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int mutex_create(void);
+int mutex_destroy(int);
+int mutex_lock(int);
+int mutex_unlock(int);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,7 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("mutex_create");
+entry("mutex_destroy");
+entry("mutex_lock");
+entry("mutex_unlock");


### PR DESCRIPTION
Утилита `test_mutex` принимает в качестве аргумента строку, использует мьютекс.
Утилита `test_no_mutex` так же принимает строку, не использует мьютекс.

Пример работы утилит:
```
$ test_no_mutex abc
4: received 'a'
4: 3re:c erievceediv e'db ''
a'
4:3:  rreecceeiivveedd  ''cb''

3: received 'c'
$ test_mutex abc
6: received 'a'
6: received 'b'
5: received 'a'
6: received 'c'
5: received 'b'
5: received 'c'
$ 
```